### PR TITLE
Avatar image file shouldn't be required in settings

### DIFF
--- a/agora_site/agora_core/forms.py
+++ b/agora_site/agora_core/forms.py
@@ -88,6 +88,8 @@ attrs_dict = {'class': 'required'}
 class UserSettingsForm(django_forms.ModelForm):
     avatar = django_forms.ImageField(_('Avatar'),
         help_text=_("Upload an image to use as avatar instead of gravatar service"))
+    delete_avatar = django_forms.BooleanField(label=_("Remove this avatar"),
+                                              required=False)
 
     short_description = django_forms.CharField(_('Short Description'),
         help_text=_("Say something about yourself (140 chars max)"), required=False)
@@ -128,14 +130,16 @@ class UserSettingsForm(django_forms.ModelForm):
         if self.user.password == '!':
             del self.fields['old_password']
             self.helper.layout = Layout(
-                Fieldset(_('Profile'), 'avatar', 'first_name', 'last_name',
+                Fieldset(_('Profile'), 'avatar', 'delete_avatar',
+                    'first_name', 'last_name',
                     'short_description', 'biography', 'email_updates'),
                 Fieldset(_('Change email'), 'email'),
                 Fieldset(_('Change password'), 'password1', 'password2')
             )
         else:
             self.helper.layout = Layout(
-                Fieldset(_('Profile'), 'avatar', 'first_name', 'last_name',
+                Fieldset(_('Profile'), 'avatar', 'delete_avatar',
+                    'first_name', 'last_name',
                     'short_description', 'biography', 'email_updates'),
                 Fieldset(_('Change email'), 'email'),
                 Fieldset(_('Change password'), 'password1', 'password2'),
@@ -150,7 +154,16 @@ class UserSettingsForm(django_forms.ModelForm):
         profile.short_description = self.cleaned_data['short_description']
         profile.biography = self.cleaned_data['biography']
         profile.email_updates = self.cleaned_data['email_updates']
-        profile.mugshot = self.cleaned_data['avatar']
+
+        avatar = self.cleaned_data['avatar']
+        if avatar:
+            if profile.mugshot:
+                profile.mugshot.delete()
+            profile.mugshot = avatar
+        if self.cleaned_data['delete_avatar']:
+            profile.mugshot.delete()
+            profile.mugshot = None
+
         user.email = self.cleaned_data['email']
         if len(self.cleaned_data['password1']) > 0:
             user.set_password(self.cleaned_data['password1'])


### PR DESCRIPTION
By default ImageField is required so we need to set required field to false. It's not needed to change the avatar every time you change the user profile.
