### PR TITLE
pytz dep in django-celery dep fails with pip 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,6 +18,7 @@ simplejson
 pygeoip
 celery==3.0.12
 django-celery==3.0.11
+pytz>dev
 django-tastypie==0.9.12
 whoosh==2.4.1
 sphinx


### PR DESCRIPTION
Related: https://github.com/pypa/pip/issues/974

Seems that pip 1.4 sees pytz's wonky year-based versioning as pre-releases, so the `--pre` flag will be needed until django-celery fixes things. This is mostly just a heads up for the next person.
